### PR TITLE
Implementing TCP timeout 

### DIFF
--- a/include/network_interface/network_interface.h
+++ b/include/network_interface/network_interface.h
@@ -101,8 +101,6 @@ namespace Network
       boost::asio::io_service io_service_;
       boost::asio::ip::tcp::socket socket_;
       boost::system::error_code error_;
-      bool timeout_triggered_;
-      bool message_received_;
       size_t bytes_read_;
 
       void timeout_handler(const boost::system::error_code& error);

--- a/include/network_interface/network_interface.h
+++ b/include/network_interface/network_interface.h
@@ -15,6 +15,7 @@
 #include <cstdio>
 #include <iostream>
 #include <boost/asio.hpp>
+#include <boost/bind.hpp>
 
 //OS Includes
 #include <unistd.h>
@@ -33,7 +34,8 @@ namespace Network
     NO_MESSAGES_RECEIVED = -5,
     READ_FAILED = -6,
     WRITE_FAILED = -7,
-    CLOSE_FAILED = -8
+    CLOSE_FAILED = -8,
+    SOCKET_TIMEOUT = -9
   };
   
   class UDPInterface
@@ -96,6 +98,13 @@ namespace Network
     private:
       boost::asio::io_service io_service_;
       boost::asio::ip::tcp::socket socket_;
+      boost::system::error_code error_;
+      bool timeout_triggered_;
+      bool message_received_;
+      size_t bytes_read_;
+
+      void timeout_handler(const boost::system::error_code& error);
+      void read_handler(const boost::system::error_code& error, size_t bytes_read);
   };
   
   //Utility Functions

--- a/include/network_interface/network_interface.h
+++ b/include/network_interface/network_interface.h
@@ -88,7 +88,8 @@ namespace Network
       // Read a message
       return_statuses read(unsigned char *msg,
                            const size_t &buf_size,
-                           size_t &bytes_read);
+                           size_t &bytes_read,
+                           int timeout_ms = 5); // Optional timeout argument, in milliseconds
       return_statuses read_exactly(unsigned char *msg,
                                    const size_t &buf_size,
                                    const size_t &bytes_to_read);

--- a/include/network_interface/network_interface.h
+++ b/include/network_interface/network_interface.h
@@ -92,7 +92,8 @@ namespace Network
                            int timeout_ms = 5); // Optional timeout argument, in milliseconds
       return_statuses read_exactly(unsigned char *msg,
                                    const size_t &buf_size,
-                                   const size_t &bytes_to_read);
+                                   const size_t &bytes_to_read,
+                                   int timeout_ms = 5); // Optional timeout argument, in milliseconds
 
       // Send a message
       return_statuses write(unsigned char *msg, const size_t &msg_size);

--- a/include/network_interface/network_interface.h
+++ b/include/network_interface/network_interface.h
@@ -89,11 +89,11 @@ namespace Network
       return_statuses read(unsigned char *msg,
                            const size_t &buf_size,
                            size_t &bytes_read,
-                           int timeout_ms = 5); // Optional timeout argument, in milliseconds
+                           int timeout_ms = 0); // Optional timeout argument, in milliseconds
       return_statuses read_exactly(unsigned char *msg,
                                    const size_t &buf_size,
                                    const size_t &bytes_to_read,
-                                   int timeout_ms = 5); // Optional timeout argument, in milliseconds
+                                   int timeout_ms = 0); // Optional timeout argument, in milliseconds
 
       // Send a message
       return_statuses write(unsigned char *msg, const size_t &msg_size);

--- a/src/tcp_interface.cpp
+++ b/src/tcp_interface.cpp
@@ -74,19 +74,75 @@ bool TCPInterface::is_open()
   return socket_.is_open();
 }
 
+// Socket timeout handler
+void TCPInterface::timeout_handler(const boost::system::error_code& error) 
+{ 
+  // Set the timeout flag and set the error code appropriately
+  timeout_triggered_ = true;
+  error_.assign(boost::system::errc::timed_out, boost::system::system_category());
+} 
+
+// Socket read handler
+void TCPInterface::read_handler(const boost::system::error_code& error, size_t bytes_read)
+{
+  // If the operation was not aborted, store the bytes that were read and set the read flag
+  if (error != boost::asio::error::operation_aborted)
+    message_received_ = true;
+    bytes_read_ = bytes_read;
+}
+
 return_statuses TCPInterface::read(unsigned char *msg,
                                    const size_t &buf_size,
                                    size_t &bytes_read)
 {
+  // Validate that the socket is connected
   if (!socket_.is_open())
     return SOCKET_CLOSED;
 
-  boost::system::error_code ec;
-  bytes_read = boost::asio::read(socket_, boost::asio::buffer(msg, buf_size), ec);
+  // Set timemout and read flags
+  timeout_triggered_ = false;
+  message_received_ = false;
 
-  if (ec.value() == boost::system::errc::success)
+  error_.assign(boost::system::errc::success, boost::system::system_category());
+
+  // Set a timer to run asychronously
+  boost::asio::deadline_timer timer(io_service_,
+                                    boost::posix_time::milliseconds(10));
+  timer.async_wait(boost::bind(&TCPInterface::timeout_handler,
+                               this,
+                               boost::asio::placeholders::error));
+  // Read the socket asychronously
+  boost::asio::async_read(socket_,
+                          boost::asio::buffer(msg, buf_size),
+                          boost::bind(&TCPInterface::read_handler,
+                                      this,
+                                      boost::asio::placeholders::error,
+                                      boost::asio::placeholders::bytes_transferred));
+  // Run until a handler is called
+  while (io_service_.run_one())
+  {
+    // If there is a callback with a received message, store the read bytes and cancel the timeout timer
+    if (message_received_)
+    {
+      timer.cancel();
+      bytes_read = bytes_read_;
+    }
+    // If the timeout is reached, cancel the socket operation
+    else if (timeout_triggered_)
+    {
+      socket_.cancel();
+    }
+  }
+  io_service_.reset();
+
+  // Return the correct error code
+  if (error_.value() == boost::system::errc::success)
   {
     return OK;
+  }
+  else if (error_.value() == boost::system::errc::timed_out)
+  {
+    return SOCKET_TIMEOUT;
   }
   else
   {

--- a/src/tcp_interface.cpp
+++ b/src/tcp_interface.cpp
@@ -98,10 +98,14 @@ return_statuses TCPInterface::read(unsigned char *msg,
   error_.assign(boost::system::errc::success, boost::system::system_category());
 
   boost::asio::deadline_timer timer(io_service_);
-  timer.expires_from_now(boost::posix_time::milliseconds(timeout_ms));
-  timer.async_wait(boost::bind(&TCPInterface::timeout_handler,
-                               this,
-                               boost::asio::placeholders::error));
+  // If requested timeout duration is set to 0 ms, don't set a deadline
+  if (timeout_ms > 0)
+  {
+    timer.expires_from_now(boost::posix_time::milliseconds(timeout_ms));
+    timer.async_wait(boost::bind(&TCPInterface::timeout_handler,
+                                this,
+                                boost::asio::placeholders::error));
+  }
 
   boost::asio::async_read(socket_,
                           boost::asio::buffer(msg, buf_size),
@@ -150,10 +154,14 @@ return_statuses TCPInterface::read_exactly(unsigned char *msg,
   error_.assign(boost::system::errc::success, boost::system::system_category());
 
   boost::asio::deadline_timer timer(io_service_);
-  timer.expires_from_now(boost::posix_time::milliseconds(timeout_ms));
-  timer.async_wait(boost::bind(&TCPInterface::timeout_handler,
-                               this,
-                               boost::asio::placeholders::error));
+  // If requested timeout duration is set to 0 ms, don't set a deadline
+  if (timeout_ms > 0)
+  {
+    timer.expires_from_now(boost::posix_time::milliseconds(timeout_ms));
+    timer.async_wait(boost::bind(&TCPInterface::timeout_handler,
+                                this,
+                                boost::asio::placeholders::error));
+  }
 
   boost::asio::async_read(socket_,
                           boost::asio::buffer(msg, buf_size),

--- a/src/tcp_interface.cpp
+++ b/src/tcp_interface.cpp
@@ -93,7 +93,8 @@ void TCPInterface::read_handler(const boost::system::error_code& error, size_t b
 
 return_statuses TCPInterface::read(unsigned char *msg,
                                    const size_t &buf_size,
-                                   size_t &bytes_read)
+                                   size_t &bytes_read,
+                                   int timeout_ms)
 {
   if (!socket_.is_open())
     return SOCKET_CLOSED;
@@ -104,7 +105,7 @@ return_statuses TCPInterface::read(unsigned char *msg,
   error_.assign(boost::system::errc::success, boost::system::system_category());
 
   boost::asio::deadline_timer timer(io_service_,
-                                    boost::posix_time::milliseconds(5));
+                                    boost::posix_time::milliseconds(timeout_ms));
   timer.async_wait(boost::bind(&TCPInterface::timeout_handler,
                                this,
                                boost::asio::placeholders::error));


### PR DESCRIPTION
This PR contains the implementation of a timeout for the TCP interface read functions. The default timeout value is set to 5 milliseconds, but may be passed in as an optional argument to the TCPInterface::read and TCPInterface::read_exactly methods. 

This PR is to resolve #2 