### PR TITLE
Fixes read_be and read_le to remove aliasing issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin/
 *.user
 *~
 .idea/
+.vscode

--- a/include/network_interface/network_utils.h
+++ b/include/network_interface/network_utils.h
@@ -24,7 +24,7 @@ namespace Network
     LE
   };
 
-  	inline int system_is_big_endian()
+  	inline bool system_is_big_endian()
 	{
 		union {
 			uint32_t i;

--- a/include/network_interface/network_utils.h
+++ b/include/network_interface/network_utils.h
@@ -24,6 +24,16 @@ namespace Network
     LE
   };
 
+  	inline int system_is_big_endian(uint32_t input)
+	{
+		union {
+			uint32_t i;
+			char c[4];
+		} big_int = {input};
+
+		return big_int.c[0] == 1; 
+	}
+
 	// little-endian
 	template<typename T>
 		T read_le(uint8_t* bufArray,
@@ -42,7 +52,7 @@ namespace Network
 		}
 
 		T retVal = 0;
-		std::memcpy(&retVal, &rcvData, sizeof(T));
+		std::memcpy(&retVal, (system_is_big_endian(rcvData)) ? &rcvData + sizeof(uint64_t) - sizeof(T) : &rcvData, sizeof(T));
 		retVal *= (T) factor;
 		retVal += valueOffset;
 
@@ -95,7 +105,7 @@ namespace Network
 		}
 		
 		T retVal;
-		std::memcpy(&retVal, &rcvData, sizeof(T));
+		std::memcpy(&retVal, (system_is_big_endian(rcvData)) ? &rcvData + sizeof(uint64_t) - sizeof(T) : &rcvData, sizeof(T));
 		retVal *= (T) factor;
 		retVal += valueOffset;
 

--- a/include/network_interface/network_utils.h
+++ b/include/network_interface/network_utils.h
@@ -13,7 +13,6 @@
 #include <vector>
 #include <typeinfo>
 #include <cstring>
-#include <stdio.h>
 
 namespace AS
 {

--- a/include/network_interface/network_utils.h
+++ b/include/network_interface/network_utils.h
@@ -12,6 +12,8 @@
 #include <cstdint>
 #include <vector>
 #include <typeinfo>
+#include <cstring>
+#include <stdio.h>
 
 namespace AS
 {
@@ -40,7 +42,10 @@ namespace Network
 			rcvData |= bufArray[(offset - 1) + i];
 		}
 
-		T retVal = (*(reinterpret_cast<T *>(&rcvData)) * (T)factor) - valueOffset;
+		T retVal = 0;
+		std::memcpy(&retVal, &rcvData, sizeof(T));
+		retVal *= (T) factor;
+		retVal += valueOffset;
 
     	return retVal;
 	};
@@ -83,14 +88,17 @@ namespace Network
 							const float& factor,
 							const unsigned int& valueOffset)
 	{
-		unsigned long rcvData = 0;
+		uint64_t rcvData = 0;
 
 		for (unsigned int i = 0; i <  size; i++) {
 			rcvData <<= 8;
 			rcvData |= bufArray[(offset) + i];
 		}
-
-		T retVal = (*(reinterpret_cast<T *>(&rcvData)) * (T)factor) - valueOffset;
+		
+		T retVal;
+		std::memcpy(&retVal, &rcvData, sizeof(T));
+		retVal *= (T) factor;
+		retVal += valueOffset;
 
 		return retVal;
 	};

--- a/include/network_interface/network_utils.h
+++ b/include/network_interface/network_utils.h
@@ -24,12 +24,12 @@ namespace Network
     LE
   };
 
-  	inline int system_is_big_endian(uint32_t input)
+  	inline int system_is_big_endian()
 	{
 		union {
 			uint32_t i;
 			char c[4];
-		} big_int = {input};
+		} big_int = {0x12345678};
 
 		return big_int.c[0] == 1; 
 	}
@@ -52,7 +52,7 @@ namespace Network
 		}
 
 		T retVal = 0;
-		std::memcpy(&retVal, (system_is_big_endian(rcvData)) ? &rcvData + sizeof(uint64_t) - sizeof(T) : &rcvData, sizeof(T));
+		std::memcpy(&retVal, (system_is_big_endian()) ? &rcvData + sizeof(uint64_t) - sizeof(T) : &rcvData, sizeof(T));
 		retVal *= (T) factor;
 		retVal += valueOffset;
 
@@ -105,7 +105,7 @@ namespace Network
 		}
 		
 		T retVal;
-		std::memcpy(&retVal, (system_is_big_endian(rcvData)) ? &rcvData + sizeof(uint64_t) - sizeof(T) : &rcvData, sizeof(T));
+		std::memcpy(&retVal, (system_is_big_endian()) ? &rcvData + sizeof(uint64_t) - sizeof(T) : &rcvData, sizeof(T));
 		retVal *= (T) factor;
 		retVal += valueOffset;
 

--- a/test/network_interface_test.cpp
+++ b/test/network_interface_test.cpp
@@ -18,7 +18,7 @@ TEST(TCPInterface, testReadBEDouble)
 
 TEST(TCPInterface, testReadBEInt)
 {
-    uint32_t in = 0x34FB5E38; //1234567891 as  hex Int
+    uint32_t in = 0x34FB5E38; //888888888 as  hex Int
     uint8_t bytes[4] = { 0x34, 0xFB, 0x5E, 0x38};
     ASSERT_EQ(888888888, AS::Network::read_be<uint32_t>(bytes, 4, 0));
 }

--- a/test/network_interface_test.cpp
+++ b/test/network_interface_test.cpp
@@ -18,9 +18,9 @@ TEST(TCPInterface, testReadBEDouble)
 
 TEST(TCPInterface, testReadBEInt)
 {
-    uint32_t in = 0x499602D3; //1234567891 as  hex Int
-    uint8_t bytes[4] = { 0x49, 0x96, 0x02, 0xD3};
-    ASSERT_EQ(1234567891, AS::Network::read_be<uint32_t>(bytes, 4, 0));
+    uint32_t in = 0x34FB5E38; //1234567891 as  hex Int
+    uint8_t bytes[4] = { 0x34, 0xFB, 0x5E, 0x38};
+    ASSERT_EQ(888888888, AS::Network::read_be<uint32_t>(bytes, 4, 0));
 }
 
 TEST(TCPInterface, testReadLEFloat)


### PR DESCRIPTION
Also adds .vscode to .gitignore for VS Code users.

gtests confirm functionality with float, double, and uint32_t