### PR TITLE
CI: Making roslint run in run_tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,6 @@ jobs:
             cd ..
             catkin build
       - run:
-          name: Lint
-          command: |
-            catkin bt --no-deps --make-args roslint
-      - run:
           name: Run Tests
           command: |
             source /opt/ros/kinetic/setup.bash
@@ -52,10 +48,6 @@ jobs:
             cd ..
             catkin build
       - run:
-          name: Lint
-          command: |
-            catkin bt --no-deps --make-args roslint
-      - run:
           name: Run Tests
           command: |
             source /opt/ros/lunar/setup.bash
@@ -83,10 +75,6 @@ jobs:
           command: |
             cd ..
             catkin build
-      - run:
-          name: Lint
-          command: |
-            catkin bt --no-deps --make-args roslint
       - run:
           name: Run Tests
           command: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,10 @@ target_link_libraries(${PROJECT_NAME}
 
 roslint_cpp()
 
+if(CATKIN_ENABLE_TESTING)
+  roslint_add_test()
+endif()
+
 #############
 ## Install ##
 #############


### PR DESCRIPTION
Moves the roslint test into run_tests, removing the need for a lint-specific set of tests in CI.