### PR TITLE
Fix memory initialization of buffer vector.

### DIFF
--- a/src/tcp_interface.cpp
+++ b/src/tcp_interface.cpp
@@ -74,7 +74,7 @@ ReturnStatuses TCPInterface::read(std::vector<uint8_t> *msg)
 
   error_.assign(boost::system::errc::success, boost::system::system_category());
 
-  msg->reserve(10000);
+  msg->resize(socket_.available(), 0);
   boost::asio::read(socket_, boost::asio::buffer(*msg), error_);
 
   // Reset the io service so that it is available for the next call to TCPInterface::read
@@ -93,7 +93,7 @@ ReturnStatuses TCPInterface::read_exactly(std::vector<uint8_t> *msg, const size_
 
   error_.assign(boost::system::errc::success, boost::system::system_category());
 
-  msg->reserve(bytes_to_read);
+  msg->resize(bytes_to_read, 0);
   boost::asio::read(socket_, boost::asio::buffer(*msg), boost::asio::transfer_exactly(bytes_to_read));
 
   // Reset the io service so that it is available for the next call to TCPInterface::read_exactly

--- a/src/udp_interface.cpp
+++ b/src/udp_interface.cpp
@@ -73,7 +73,7 @@ ReturnStatuses UDPInterface::read(std::vector<uint8_t> *msg)
     return ReturnStatuses::SOCKET_CLOSED;
 
   boost::system::error_code ec;
-  msg->reserve(10000);
+  msg->resize(socket_.available(), 0);
   socket_.receive(boost::asio::buffer(*msg), 0, ec);
 
   if (ec.value() == boost::system::errc::success)


### PR DESCRIPTION
As described by @likun1993630 in https://github.com/astuff/ibeo_lux/issues/16#issuecomment-527675932, the `std::vector` buffer is not initialized properly before being passed to `boost::asio::read`. This fixes this error.