### PR TITLE
CI: Disable docker layer caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,6 @@ jobs:
   kinetic_armhf:
     machine:
       image: circleci/classic:latest
-      docker_layer_caching: true
     steps:
       - checkout
       - run:
@@ -93,7 +92,6 @@ jobs:
   melodic_armhf:
     machine:
       image: circleci/classic:latest
-      docker_layer_caching: true
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Resolves #28 by disabling docker layer caching. Builds were failing since it now seems to be a paid feature.