### PR TITLE
UDP Server Class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(
   ${PROJECT_NAME}
   src/tcp_interface.cpp
   src/udp_interface.cpp
+  src/udp_server.cpp
   src/utils.cpp
 )
 

--- a/include/network_interface/network_interface.h
+++ b/include/network_interface/network_interface.h
@@ -35,8 +35,8 @@ public:
   UDPInterface();
 
   // Called to pass in parameters and open ethernet link
-  ReturnStatuses open(std::string ip_address, const int &port, uint receive_buffer_size);
-  ReturnStatuses open(std::string ip_address, const int &port);
+  ReturnStatuses open(const std::string& ip_address, uint32_t port, uint32_t receive_buffer_size);
+  ReturnStatuses open(const std::string& ip_address, uint32_t port);
 
   // Close the ethernet link
   ReturnStatuses close();
@@ -51,7 +51,7 @@ public:
   ReturnStatuses write(const std::vector<uint8_t>& msg);
 
 private:
-  uint receive_buffer_size_ = 1024;
+  uint32_t receive_buffer_size_ = 1024;
   boost::asio::io_service io_service_;
   boost::asio::ip::udp::socket socket_;
   boost::asio::ip::udp::endpoint sender_endpoint_;

--- a/include/network_interface/udp_server.h
+++ b/include/network_interface/udp_server.h
@@ -1,0 +1,74 @@
+/*
+* Unpublished Copyright (c) 2009-2021 AutonomouStuff, LLC, All Rights Reserved.
+*
+* This file is part of the network_interface ROS 1.0 driver which is released under the MIT license.
+* See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
+*/
+
+// Define a class that supports a basic network interface that's independent of the hardware and driver library used
+// Different libraries can be created to define all these functions for a specific driver library
+
+#ifndef NETWORK_INTERFACE_UDP_SERVER_H
+#define NETWORK_INTERFACE_UDP_SERVER_H
+
+#include "network_interface/common.h"
+
+// C++ Includes
+#include <cstdio>
+#include <iostream>
+#include <string>
+#include <vector>
+#include <boost/asio.hpp>
+#include <boost/bind.hpp>
+
+// OS Includes
+#include <unistd.h>
+
+namespace AS
+{
+namespace Network
+{
+
+class UDPServer
+{
+public:
+  UDPServer();
+
+  // Called to pass in parameters and open ethernet link
+  ReturnStatuses open(const std::string& ip_address, uint32_t port);
+
+  // Close the bound socket connection
+  ReturnStatuses close();
+
+  // Check on the status of the link
+  bool is_open();
+
+  // Register a callback for receiving data and sending a response
+  void registerReceiveHandler(std::function<std::vector<uint8_t>(const std::vector<uint8_t>&)> callback);
+
+  // Run the io_service, will block until shutdown
+  void run();
+
+private:
+  // Queue an io_service task for receiving on the socket
+  void startReceive();
+
+  // Callback for when received data is ready
+  void handleReceive(const boost::system::error_code& error, std::size_t bytes_transferred);
+
+  // Callback for when server replies are sent
+  void handleSend(std::vector<uint8_t> sent_payload,
+    const boost::system::error_code& ec, std::size_t bytes_transferred);
+
+  boost::asio::io_service io_service_;
+  boost::asio::ip::udp::socket socket_;
+  boost::asio::ip::udp::endpoint server_endpoint_;
+  boost::asio::ip::udp::endpoint client_endpoint_;
+  std::function<std::vector<uint8_t>(const std::vector<uint8_t>&)> receive_callback_;
+};
+
+std::string return_status_desc(const ReturnStatuses &ret);
+
+}  // namespace Network
+}  // namespace AS
+#endif  // NETWORK_INTERFACE_UDP_SERVER_H

--- a/src/udp_interface.cpp
+++ b/src/udp_interface.cpp
@@ -19,13 +19,13 @@ UDPInterface::UDPInterface() :
 {
 }
 
-ReturnStatuses UDPInterface::open(std::string ip_address, const int &port, uint receive_buffer_size)
+ReturnStatuses UDPInterface::open(const std::string& ip_address, uint32_t port, uint32_t receive_buffer_size)
 {
   receive_buffer_size_ = receive_buffer_size;
   return UDPInterface::open(ip_address, port);
 }
 
-ReturnStatuses UDPInterface::open(std::string ip_address, const int &port)
+ReturnStatuses UDPInterface::open(const std::string& ip_address, uint32_t port)
 {
   if (socket_.is_open())
     return ReturnStatuses::OK;
@@ -89,7 +89,7 @@ ReturnStatuses UDPInterface::read(std::vector<uint8_t> *msg)
     return ReturnStatuses::READ_FAILED;
 }
 
-ReturnStatuses UDPInterface::write(const std::vector<uint8_t> &msg)
+ReturnStatuses UDPInterface::write(const std::vector<uint8_t>& msg)
 {
   if (!socket_.is_open())
     return ReturnStatuses::SOCKET_CLOSED;

--- a/src/udp_server.cpp
+++ b/src/udp_server.cpp
@@ -1,0 +1,125 @@
+/*
+* Unpublished Copyright (c) 2009-2021 AutonomouStuff, LLC, All Rights Reserved.
+*
+* This file is part of the network_interface ROS 1.0 driver which is released under the MIT license.
+* See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
+*/
+
+#include <network_interface/udp_server.h>
+
+#include <string>
+#include <vector>
+
+using namespace AS::Network;  // NOLINT
+using boost::asio::ip::udp;
+
+UDPServer::UDPServer() :
+  socket_(io_service_)
+{
+}
+
+ReturnStatuses UDPServer::open(const std::string& ip_address, uint32_t port)
+{
+  if (socket_.is_open())
+  {
+    return ReturnStatuses::OK;
+  }
+
+  std::stringstream sPort;
+  sPort << port;
+  udp::resolver res(io_service_);
+  udp::resolver::query query(udp::v4(), ip_address.c_str(), sPort.str());
+  server_endpoint_ = *res.resolve(query);
+  boost::system::error_code ec;
+
+  socket_.open(boost::asio::ip::udp::v4(), ec);
+  socket_.bind(server_endpoint_, ec);
+
+  if (ec.value() == boost::system::errc::success)
+  {
+    return ReturnStatuses::OK;
+  }
+  else if (ec.value() == boost::asio::error::invalid_argument)
+  {
+    return ReturnStatuses::BAD_PARAM;
+  }
+  else
+  {
+    close();
+    return ReturnStatuses::INIT_FAILED;
+  }
+}
+
+ReturnStatuses UDPServer::close()
+{
+  if (!socket_.is_open())
+  {
+    return ReturnStatuses::SOCKET_CLOSED;
+  }
+
+  boost::system::error_code ec;
+  socket_.close(ec);
+
+  if (ec.value() == boost::system::errc::success)
+  {
+    return ReturnStatuses::OK;
+  }
+  else
+  {
+    return ReturnStatuses::CLOSE_FAILED;
+  }
+}
+
+bool UDPServer::is_open()
+{
+  return socket_.is_open();
+}
+
+void UDPServer::registerReceiveHandler(std::function<std::vector<uint8_t>(const std::vector<uint8_t>&)> callback)
+{
+  receive_callback_ = callback;
+  startReceive();
+}
+
+void UDPServer::startReceive()
+{
+  socket_.async_receive_from(
+    boost::asio::null_buffers(), client_endpoint_,
+    boost::bind(&UDPServer::handleReceive, this,
+      boost::asio::placeholders::error,
+      boost::asio::placeholders::bytes_transferred));
+}
+
+void UDPServer::handleReceive(const boost::system::error_code& error, std::size_t bytes_transferred)
+{
+  if (!error || error == boost::asio::error::message_size)
+  {
+    std::vector<uint8_t> payload;
+    boost::system::error_code ec;
+    unsigned int available = socket_.available();
+    payload.resize(available, 0);
+
+    uint32_t payload_size = socket_.receive_from(boost::asio::buffer(payload, available),
+      client_endpoint_, 0, ec);
+
+    // User callback
+    std::vector<uint8_t> response = receive_callback_(payload);
+
+    // Send response
+    socket_.async_send_to(boost::asio::buffer(response), client_endpoint_,
+      boost::bind(&UDPServer::handleSend, this, response,
+        boost::asio::placeholders::error,
+        boost::asio::placeholders::bytes_transferred));
+  }
+}
+
+void UDPServer::handleSend(std::vector<uint8_t> sent_payload,
+  const boost::system::error_code& ec, std::size_t bytes_transferred)
+{
+  startReceive();
+}
+
+void UDPServer::run()
+{
+  io_service_.run();
+}

--- a/src/udp_server.cpp
+++ b/src/udp_server.cpp
@@ -92,14 +92,17 @@ void UDPServer::startReceive()
 
 void UDPServer::handleReceive(const boost::system::error_code& error, std::size_t bytes_transferred)
 {
+  // unused
+  (void)bytes_transferred;
+
   if (!error || error == boost::asio::error::message_size)
   {
     std::vector<uint8_t> payload;
     boost::system::error_code ec;
-    unsigned int available = socket_.available();
+    uint32_t available = socket_.available();
     payload.resize(available, 0);
 
-    uint32_t payload_size = socket_.receive_from(boost::asio::buffer(payload, available),
+    socket_.receive_from(boost::asio::buffer(payload, available),
       client_endpoint_, 0, ec);
 
     // User callback
@@ -116,6 +119,11 @@ void UDPServer::handleReceive(const boost::system::error_code& error, std::size_
 void UDPServer::handleSend(std::vector<uint8_t> sent_payload,
   const boost::system::error_code& ec, std::size_t bytes_transferred)
 {
+  // unused
+  (void)sent_payload;
+  (void)ec;
+  (void)bytes_transferred;
+
   startReceive();
 }
 


### PR DESCRIPTION
Resolves #34 
This PR adds a UDP server class for generic/easy use of a UDP server. This differs from the existing content in this repo by providing an asynchronous UDP server that binds to a specific socket (address and port), rather than blocking reads/writes to certain remote endpoints.

The implementation is heavily inspired by the UDP server boost example:
https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/example/cpp11/echo/async_udp_echo_server.cpp 

Also some small updates to `UDPInterface` from Jilin's review of the previous PR.