### PR TITLE
Add stop function for terminating UDP Server

### DIFF
--- a/include/network_interface/udp_server.h
+++ b/include/network_interface/udp_server.h
@@ -49,6 +49,9 @@ public:
   // Run the io_service, will block until shutdown
   void run();
 
+  // Stop the io_service, thread safe
+  void stop();
+
 private:
   // Queue an io_service task for receiving on the socket
   void startReceive();

--- a/src/udp_server.cpp
+++ b/src/udp_server.cpp
@@ -131,3 +131,8 @@ void UDPServer::run()
 {
   io_service_.run();
 }
+
+void UDPServer::stop()
+{
+  io_service_.stop();
+}


### PR DESCRIPTION
I missed this in the previous PR, a stop function is needed to terminate the io_service cleanly.