### PR TITLE
UDP Server: Don't send reply if zero length

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
       - run:
           name: Set Up ROS in Docker
           command: |
-            docker exec test /bin/bash -c "source \`find /opt/ros -name setup.bash | sort | head -1\` && rosdep install --from-paths src --ignore-src -y"
+            docker exec test /bin/bash -c "apt update && source \`find /opt/ros -name setup.bash | sort | head -1\` && rosdep install --from-paths src --ignore-src -y"
             docker exec test /bin/bash -c "source \`find /opt/ros -name setup.bash | sort | head -1\` && catkin init && catkin config --extend /opt/ros/\$ROS_DISTRO"
       - run:
           name: Build in Docker
@@ -106,7 +106,7 @@ jobs:
       - run:
           name: Set Up ROS in Docker
           command: |
-            docker exec test /bin/bash -c "source \`find /opt/ros -name setup.bash | sort | head -1\` && rosdep install --from-paths src --ignore-src -y"
+            docker exec test /bin/bash -c "apt update && source \`find /opt/ros -name setup.bash | sort | head -1\` && rosdep install --from-paths src --ignore-src -y"
             docker exec test /bin/bash -c "source \`find /opt/ros -name setup.bash | sort | head -1\` && catkin init && catkin config --extend /opt/ros/\$ROS_DISTRO"
       - run:
           name: Build in Docker
@@ -167,7 +167,7 @@ jobs:
       - run:
           name: Set Up ROS in Docker
           command: |
-            docker exec test /bin/bash -c "source \`find /opt/ros -name setup.bash | sort | head -1\` && rosdep install --from-paths src --ignore-src -y"
+            docker exec test /bin/bash -c "apt update && source \`find /opt/ros -name setup.bash | sort | head -1\` && rosdep install --from-paths src --ignore-src -y"
             docker exec test /bin/bash -c "source \`find /opt/ros -name setup.bash | sort | head -1\` && catkin init && catkin config --extend /opt/ros/\$ROS_DISTRO"
       - run:
           name: Build in Docker

--- a/src/udp_server.cpp
+++ b/src/udp_server.cpp
@@ -109,10 +109,17 @@ void UDPServer::handleReceive(const boost::system::error_code& error, std::size_
     std::vector<uint8_t> response = receive_callback_(payload);
 
     // Send response
-    socket_.async_send_to(boost::asio::buffer(response), client_endpoint_,
-      boost::bind(&UDPServer::handleSend, this, response,
-        boost::asio::placeholders::error,
-        boost::asio::placeholders::bytes_transferred));
+    if (response.size() > 0)
+    {
+      socket_.async_send_to(boost::asio::buffer(response), client_endpoint_,
+        boost::bind(&UDPServer::handleSend, this, response,
+          boost::asio::placeholders::error,
+          boost::asio::placeholders::bytes_transferred));
+    }
+    else
+    {
+      startReceive();
+    }
   }
 }
 


### PR DESCRIPTION
Resolves #37 by only sending out the reply packet if there is data to send.
Can be useful in situations where you just want to bind and listen to a UDP port.